### PR TITLE
Remove install plugin requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <a href="https://www.npmjs.com/package/laravel-mix-definitions"><img src="https://img.shields.io/npm/v/laravel-mix-definitions.svg?style=for-the-badge" alt="npm" /></a> <a href="https://www.npmjs.com/package/laravel-mix-definitions"><img src="https://img.shields.io/npm/dt/laravel-mix-definitions.svg?style=for-the-badge" alt="npm" /></a>
 </h1>
 
-Add and/or update definitions for the webpack build, using Laravel Mix.
+Add and/or update definitions for the webpack build, using [Laravel Mix](https://laravel-mix.com/).
 
 Read more about how definitions work with the [Define Plugin](https://webpack.js.org/plugins/define-plugin/).
 
@@ -18,7 +18,7 @@ npm install laravel-mix-definitions --save-dev
 
 ```js
 const mix = require('laravel-mix');
-require('laravel-mix-definitions').installPlugin(mix);
+require('laravel-mix-definitions');
 
 mix.definition('$', 'jQuery');
 mix.definition('_', 'lodash');

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "laravel-mix-definitions",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Plugin for adding custom definitions for DefinePlugin.",
   "main": "src/LaravelMixDefinitions.js",
+  "peerDependencies": {
+    "laravel-mix": ">=2.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Erutan409/laravel-mix-definitions.git"

--- a/src/LaravelMixDefinitions.js
+++ b/src/LaravelMixDefinitions.js
@@ -1,20 +1,35 @@
 const Assert = require('assert');
-const Api = require('laravel-mix/src/Api');
 const find = require('lodash/find');
 const forIn = require('lodash/forIn');
+const mix = require('laravel-mix');
 
+// TODO remove in next major release (2.0.0)
+let installed = false;
+
+let definitions = {};
+
+/**
+ * Laravel Mix Definitions
+ *
+ * Provide straight-forward way of defining global constraints.
+ */
 class LaravelMixDefinitions {
 
     /**
      * Install the plugin for Laravel Mix.
      *
-     * @param {Api} mix
+     * @return {this}
      */
-    static installPlugin(mix) {
+    static installPlugin() {
 
-        Assert(mix instanceof Api, 'Expecting valid instance of Laravel Mix Api.');
+        // TODO remove in next major release (2.0.0)
+        if (installed) {
 
-        let definitions = {};
+            console.warn(`Calling ${this.name}.installPlugin() directly is now deprecated and will be removed in the next major version.`);
+
+            return;
+
+        }
 
         mix.extend('definition', new class {
 
@@ -65,8 +80,14 @@ class LaravelMixDefinitions {
 
         });
 
+        // TODO remove in next major release (2.0.0)
+        installed = true;
+
+        return this;
+
     }
 
 }
 
-module.exports = LaravelMixDefinitions;
+// TODO remove in next major release (2.0.0)
+module.exports = LaravelMixDefinitions.installPlugin();


### PR DESCRIPTION
* Removed unnecessary requirement for installing plugin with Api instance
  * Added warning that continued use of this functionality will be deprecated in next major release
* Updated README